### PR TITLE
Avoid greylisting when SPF is strict/valid and use greylisting when S…

### DIFF
--- a/__default__.dist
+++ b/__default__.dist
@@ -1,6 +1,8 @@
 SPFSEEDONLY = 0
 GREYLISTTIME = 600
 CHECKERS = spf,greylist
+CHECKNEXTIFSPFFAILS = 0
+SPFVALIDATIONISENOUGH = 0
 OTHERCONFIGS = client_address,envelope_sender,envelope_recipient
 
 #  The number of days after which, if no messages have come in, we will

--- a/tumgreyspf
+++ b/tumgreyspf
@@ -394,9 +394,24 @@ while 1:
             elif checkerType == 'spf':
                 checkerValue, checkerReason = spfcheck(data, configData,
                         configGlobal)
+                if debugLevel >= 4:
+                    syslog.syslog('SPF check returned %s - %s' %
+                                  (checkerValue, checkerReason))
                 if configData.get('SPFSEEDONLY', 0):
                     checkerValue = None
                     checkerReason = None
+                if configData.get('CHECKNEXTIFSPFFAILS', 0) and \
+                        (checkerValue == 'reject' or checkerValue == 'defer'):
+                    # if SPF fails and we set the config, continue anyway
+                    syslog.syslog('Failed SPF, but will check next checker '
+                                  'anyway')
+                    checkerValue = None
+                    checkerReason = None
+                if configData.get('SPFVALIDATIONISENOUGH',0) and \
+                                checkerValue == 'prepend':
+                    # Do not further validate the email; spf is enough
+                    syslog.syslog('Passed SPF, no more checks necessary')
+                    break
                 if checkerValue != None and checkerValue != 'prepend':
                     break
             elif checkerType == 'blackhole':

--- a/tumgreyspfsupp.py
+++ b/tumgreyspfsupp.py
@@ -125,6 +125,8 @@ def readConfigFile(path, configData = None, configGlobal = {}):
 			'SPFSEEDONLY' : int,
 			'GREYLISTTIME' : int,
 			'CHECKERS' : str,
+			'CHECKNEXTIFSPFFAILS' : int,
+			'SPFVALIDATIONISENOUGH' : int,
 			'OTHERCONFIGS' : str,
 			'GREYLISTEXPIREDAYS' : float,
 			}


### PR DESCRIPTION
…PF fails
- Added an option to avoid/ignore the greylisting when SPF passes
- Added an option to perform greylisting anyway if SPF fails

This solution would close #1.

This has been running on my server for half a year without any problems
so far.
